### PR TITLE
♻️ content/themes: Use Hugo standard `images` for cover and OG images

### DIFF
--- a/content/blog/2015/11/gotta-badge-em-introduction-fedora-badges.md
+++ b/content/blog/2015/11/gotta-badge-em-introduction-fedora-badges.md
@@ -10,7 +10,7 @@ tags:
   - "fedora"
   - "fedora-planet"
   - "gotta-badge-em-all"
-coverImage: "Fedora-Badges.png"
+images: ["/blog/2015/11/Fedora-Badges.png"]
 ---
 
 ## What is this?!

--- a/content/blog/2016/03/why-i-love-wichacks.md
+++ b/content/blog/2016/03/why-i-love-wichacks.md
@@ -13,7 +13,7 @@ tags:
   - "hfoss"
   - "rochester-institute-of-technology"
   - "women-in-computing-wic"
-coverImage: "/img/WiCHacks-Opening-Ceremony.jpg"
+images: ["/img/WiCHacks-Opening-Ceremony.jpg"]
 ---
 
 Two weekends ago, from February 27th to the 28th, the [Women in Computing](http://wic.rit.edu) program at the [Rochester Institute of Technology](https://www.rit.edu/) hosted their third annual [WiCHacks](http://wichacks.rit.edu/) hackathon. WiCHacks is a women-only hackathon open to university students and high school juniors and seniors. WiCHacks is a collaborative event bringing women together from across RIT, the country, and even the world (including attendees from Germany). The participants are in a supportive and empowering environment to build something awesome and present it to everyone else in the span of one weekend.

--- a/content/blog/2016/04/brickhack-2016.md
+++ b/content/blog/2016/04/brickhack-2016.md
@@ -14,7 +14,7 @@ tags:
   - "friends"
   - "hfoss"
   - "rochester-institute-of-technology"
-coverImage: "Hacksesh-02-min.jpg"
+images: ["/blog/2016/04/Hacksesh-02-min.jpg"]
 ---
 
 Last month at the [Rochester Institute of Technology](https://www.rit.edu/), [BrickHack 2016](https://brickhack.io/) came to a close. BrickHack is an annual hackathon organized by students at RIT. Close to 300 people attend every year. This year was BrickHack's second event.

--- a/content/blog/2016/04/google-summer-code-fedora-class-2016.md
+++ b/content/blog/2016/04/google-summer-code-fedora-class-2016.md
@@ -14,7 +14,7 @@ tags:
   - "hfoss"
   - "open-source"
   - "summer-activities"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 This summer, I'm excited to say I will be trying on a new pair of socks for size.

--- a/content/blog/2016/05/tribute-halo-3-odst-soundtrack.md
+++ b/content/blog/2016/05/tribute-halo-3-odst-soundtrack.md
@@ -6,7 +6,7 @@ categories:
 tags: 
   - "halo"
   - "music-review"
-coverImage: "halo-3-odst-resized.jpg"
+images: ["/blog/2016/05/halo-3-odst-resized.jpg"]
 ---
 
 The time is nearing 2:00am on a Wednesday morning. Outside is dark, a swirling mist of rain and blurred lights. As I stare out the window, the white light from my laptop illuminates my face. Around me, a room that is as quiet as the deserted roads and parking lots I see from my window. This is the scene that surrounds me as I listen to the 2009 [Halo 3: ODST](https://en.wikipedia.org/wiki/Halo_3:_ODST) Original Soundtrack. Anyone who knows me well knows that I love the Halo series, especially the music that surrounds it.

--- a/content/blog/2016/06/fedora-ambassadors-communicating-design.md
+++ b/content/blog/2016/06/fedora-ambassadors-communicating-design.md
@@ -12,7 +12,7 @@ tags:
   - "fedora-planet"
   - "open-source"
   - "working-together"
-coverImage: "ambassadors-communicating-design.png"
+images: ["/blog/2016/06/ambassadors-communicating-design.png"]
 ---
 
 This week is busy and continues to keep the pace of previous weeks. A lot has happened this week in the Fedora Project and I've taken on a few new tasks too. In addition to existing work on [Google Summer of Code](https://jwfblog.wpenginepowered.com/tag/gsoc/feed/), Community Operations, Marketing, and more, I wanted to take some time this week to focus on CommOps [Ticket #71](https://fedorahosted.org/fedora-commops/ticket/71). This ticket originally focused on improving accessibility of design resources for Fedora [Ambassadors](https://fedoraproject.org/wiki/Ambassadors). However, after an interesting conversation with [Máirín Duffy](https://fedoraproject.org/wiki/User:Duffy) on the [Design Team](https://fedoraproject.org/wiki/Design) workflow, I discovered the availability was not the main issue. Instead, it seemed like communicating was an area needing focus.

--- a/content/blog/2016/06/gsoc-2016-rundown-assembling-orchestra.md
+++ b/content/blog/2016/06/gsoc-2016-rundown-assembling-orchestra.md
@@ -11,7 +11,7 @@ tags:
   - "fedora-magazine"
   - "fedora-planet"
   - "gsoc"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 This week is the [Google Summer of Code 2016](https://summerofcode.withgoogle.com/) midterm evaluation week. Over the past month since the program started, I've learned more about the technology I'm working with, implementing it within my infrastructure, and moving closer to completing my proposal. My [original project proposal](https://fedoraproject.org/wiki/GSOC_2016/Student_Application_jflory7) details how I am working with [Ansible](https://www.ansible.com/) to bring improved automation for WordPress platforms within Fedora, particularly to the [Fedora Community Blog](https://communityblog.fedoraproject.org/) and the [Fedora Magazine](https://fedoramagazine.org/).

--- a/content/blog/2016/06/setting-vagrant-testing-ansible.md
+++ b/content/blog/2016/06/setting-vagrant-testing-ansible.md
@@ -15,7 +15,7 @@ tags:
   - "open-source"
   - "vagrant"
   - "virtual-machines-vm"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 As part of my [Google Summer of Code](https://summerofcode.withgoogle.com/) project proposal for the [Fedora Project](https://fedoraproject.org/wiki/Overview), I've spent a lot of time learning about the ins and outs of Ansible. [Ansible](https://www.ansible.com/) is a handy task and configuration automation utility. In the Fedora Project, Ansible is [used extensively](https://infrastructure.fedoraproject.org/cgit/ansible.git/) in Fedora's infrastructure. But if you're first starting to learn Ansible, it might be tricky to test and play with it if you don't have production or development servers you can use. This is where Vagrant comes in.

--- a/content/blog/2016/07/czesc-poland-back-europe.md
+++ b/content/blog/2016/07/czesc-poland-back-europe.md
@@ -13,7 +13,7 @@ tags:
   - "open-source"
   - "poland"
   - "travel"
-coverImage: "poland-flock-2016.png"
+images: ["/blog/2016/07/poland-flock-2016.png"]
 ---
 
 Earlier this month, I received some of the most exciting news I have had all year. After much finger-crossing and (hopefully) hard work, I am traveling to Kraków, Poland, for the [Fedora Project](https://fedoraproject.org/wiki/Overview)'s annual [Flock](https://flocktofedora.org/) conference. Flock is described by the organizers as the following.

--- a/content/blog/2016/07/gsoc-2016-documentation-upgrades.md
+++ b/content/blog/2016/07/gsoc-2016-documentation-upgrades.md
@@ -15,7 +15,7 @@ tags:
   - "gsoc"
   - "summer-activities"
   - "wordpress"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 This week and the last were busy, but I've made some more progress towards creating the last, idempotent product for managing WordPress installations in Fedora's Infrastructure for GSoC 2016. The past two weeks had me mostly working on writing the standard operating procedure / documentation for my final product as well as diving more into handling upgrades with WordPress. My primary playbook for installing WordPress is mostly complete, pending [one last annoyance](https://serverfault.com/questions/790104/using-external-variables-inside-of-an-ansible-template/790111?noredirect=1#comment999485_790111).

--- a/content/blog/2016/07/gsoc-2016-moving-towards-staging.md
+++ b/content/blog/2016/07/gsoc-2016-moving-towards-staging.md
@@ -15,7 +15,7 @@ tags:
   - "gsoc"
   - "summer-activities"
   - "wordpress"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 This week wraps up for July and the last period of Google Summer of Code (GSoC 2016) is almost here. As the summer comes to a close, I'm working on the last steps for preparing my project for deployment into Fedora's [Ansible infrastructure](https://infrastructure.fedoraproject.org/cgit/ansible.git/). Once it checks out in a staging instance, it can make the move to production.

--- a/content/blog/2016/07/gsoc-2016-wordpress-networks.md
+++ b/content/blog/2016/07/gsoc-2016-wordpress-networks.md
@@ -11,7 +11,7 @@ tags:
   - "open-source"
   - "research-and-learning"
   - "wordpress"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 This week, with an [initial playbook](https://pagure.io/jflory7-ansible/blob/master/f/playbooks/deliverables) for creating a WordPress installation created (albeit needing polish), my next focus was to look at the idea of creating a WordPress [multi-site network](https://codex.wordpress.org/Create_A_Network). Creating a multi-site network would offer the benefits of only having to keep up a single base installation, with new sites extending from the same core of WordPress. Before making further refinements to the playbook, I wanted to investigate whether a WordPress network would be the best fit for Fedora.

--- a/content/blog/2016/07/push-fedora-badges.md
+++ b/content/blog/2016/07/push-fedora-badges.md
@@ -9,7 +9,7 @@ tags:
   - "fedora-infrastructure"
   - "fedora"
   - "fedora-planet"
-coverImage: "push-fedora-badges.png"
+images: ["/blog/2016/07/push-fedora-badges.png"]
 ---
 
 Ever wondered what goes on behind the magic of [Fedora Badges](https://badges.fedoraproject.org/)? How does a badge go from being a design to an earn-able entity? This short but handy guide breaks down the entire process for you. This post is adapted from a [series of notes](https://meetbot.fedoraproject.org/fedora-meeting-3/2016-06-03/commops.2016-06-03-20.56.log.html#l-34) I took while watching Ralph Bean demo the procedure at [PyCon](https://fedoraproject.org/wiki/PyCon_2016). This guide is a supplement, not a replacement, for the official [Badges SOP](https://infrastructure.fedoraproject.org/infra/docs/badges.rst).

--- a/content/blog/2016/08/achievement-get-rainbow.md
+++ b/content/blog/2016/08/achievement-get-rainbow.md
@@ -8,7 +8,7 @@ tags:
   - "fedora-badges"
   - "fedora"
   - "fedora-planet"
-coverImage: "achievement-get-rainbow.png"
+images: ["/blog/2016/08/achievement-get-rainbow.png"]
 ---
 
 Earlier this month, I received the [_Rainbow_ badge](https://badges.fedoraproject.org/badge/rainbow-cookie-v) in [Fedora Badges](https://badges.fedoraproject.org/about). _Rainbow_ is the fifth badge in a series for receiving "karma cookies" from others in IRC. Every time I receive a new badge in this series, I like to [reflect](https://jwfblog.wpenginepowered.com/2016/03/achievement-get-pizzelle/) back on the past and where my Fedora journey has taken me [since October 2015](https://jwfblog.wpenginepowered.com/2015/10/my-journey-into-fedora/).

--- a/content/blog/2016/08/fedora-flock-2016.md
+++ b/content/blog/2016/08/fedora-flock-2016.md
@@ -18,7 +18,7 @@ tags:
   - "flock"
   - "flock-2016"
   - "poland"
-coverImage: "zegnajcie-fedora-flock-2016.jpg"
+images: ["/blog/2016/08/zegnajcie-fedora-flock-2016.jpg"]
 ---
 
 From August 2 - 5, the annual Fedora contributor conference, [Flock](https://flocktofedora.org/), was held in the beautiful city of [Kraków, Poland](https://en.wikipedia.org/wiki/Krak%C3%B3w). Fedora contributors from all over the world attend for a week of talks, workshops, collaboration, fun, and community building (if you're tuning in and not sure what Fedora is exactly, you can read more [here](https://fedoraproject.org/wiki/Overview)). Talks range from technical topics dealing with upcoming changes to the distribution, talks focusing on the community and things working well and how to improve, and many more. The workshops are a chance for people normally separated by thousands of miles to work and collaborate on real issues, problems, and tasks in the same room. As a Fedora contributor, this is the "premier" event to attend as a community member.

--- a/content/blog/2016/08/gsoc-2016-thats-wrap.md
+++ b/content/blog/2016/08/gsoc-2016-thats-wrap.md
@@ -14,7 +14,7 @@ tags:
   - "gsoc"
   - "open-source"
   - "summer-activities"
-coverImage: "/img/Google-Summer-of-Code-announcement.png"
+images: ["/img/Google-Summer-of-Code-announcement.png"]
 ---
 
 Tomorrow, August 22, 2016, marks the end of the [Google Summer of Code](https://summerofcode.withgoogle.com/) 2016 program. This year, I participated as a student for the Fedora Project working on my proposal, "[_Ansible and the Community (or automation improving innovation)_](https://summerofcode.withgoogle.com/archive/2016/projects/4844704050970624/)". You can read my [original project proposal](https://fedoraproject.org/wiki/GSOC_2016/Student_Application_jflory7) on the Fedora wiki. Over the summer, I spent time learning more about [Ansible](https://www.ansible.com/), applying the knowledge to real-world applications, and then taking that experience and writing my final deliverable. The last deliverable items, closing plans, and thoughts on the journey are detailed as follows.

--- a/content/blog/2016/08/new-role-fedora-magazine-editor-in-chief.md
+++ b/content/blog/2016/08/new-role-fedora-magazine-editor-in-chief.md
@@ -7,7 +7,7 @@ tags:
   - "fedora"
   - "fedora-magazine"
   - "fedora-planet"
-coverImage: "new-role-magazine-editor-in-chief.png"
+images: ["/blog/2016/08/new-role-magazine-editor-in-chief.png"]
 ---
 
 ![Picture from Flock 2016 with Justin Wheeler and Ryan Lerch for Fedora Magazine](/blog/2016/08/IMG_9424.jpg "Me (left) with Ryan Lerch (right) at Flock 2016 (https://flocktofedora.org/)")

--- a/content/blog/2016/10/converting-sounds-words-sudden-miss-everyone.md
+++ b/content/blog/2016/10/converting-sounds-words-sudden-miss-everyone.md
@@ -10,7 +10,7 @@ tags:
   - "music"
   - "music-review"
   - "post-rock"
-coverImage: "All-of-a-Sudden-I-Miss-Everyone.jpg"
+images: ["/blog/2016/10/All-of-a-Sudden-I-Miss-Everyone.jpg"]
 ---
 
 The dancer gracefully glides across the stage, with a slow but determined gait radiant with purpose. The movement is not her own, but neither is it forced. The sound uncoils itself as a rope and instructs the dancer forward, synchronizing her movement with the delicate pressure of the pianist's fingers. There is no consciousness, no concept of time. The moment is forever captured in the combination of auditory and visual perception. Without a single spoken word, an emotion is tearing at the seams of the casual observer.

--- a/content/blog/2016/10/hackmit-meets-fedora.md
+++ b/content/blog/2016/10/hackmit-meets-fedora.md
@@ -16,7 +16,7 @@ tags:
   - "hackmit-2016"
   - "outreach"
   - "what-its-all-about"
-coverImage: "Team-Ubuntu-2-compressed.jpg"
+images: ["/blog/2016/10/Team-Ubuntu-2-compressed.jpg"]
 ---
 
 _This post was originally published on the [Fedora Community Blog](https://communityblog.fedoraproject.org/hackmit-meets-fedora/)._

--- a/content/blog/2016/10/light-dark.md
+++ b/content/blog/2016/10/light-dark.md
@@ -7,7 +7,7 @@ tags:
   - "2010s"
   - "archives-journals"
   - "throwback-drafts"
-coverImage: "light-dark.jpg"
+images: ["/blog/2016/10/light-dark.jpg"]
 ---
 
 _This post is published as part of a personal archival project of [my poetry](https://jwfblog.wpenginepowered.com/category/poems/) and other creative works. The actual publish date of this post is Friday, April 19th, 2024, but the publish date of the post reflects the original date of authorship. This archival project aims to digitize a selection of written works that exist only in my private records. Enjoy._

--- a/content/blog/2016/10/minecraft-involved-open-source-community.md
+++ b/content/blog/2016/10/minecraft-involved-open-source-community.md
@@ -16,7 +16,7 @@ tags:
   - "open-source"
   - "rochester-institute-of-technology"
   - "spigotmc"
-coverImage: "myopensourcestory.png"
+images: ["/blog/2016/10/myopensourcestory.png"]
 ---
 
 [_This post was originally published on OpenSource.com._](https://opensource.com/life/16/10/my-open-source-story-justin-flory)

--- a/content/blog/2016/10/set-up-github-organizations-clubs.md
+++ b/content/blog/2016/10/set-up-github-organizations-clubs.md
@@ -12,7 +12,7 @@ tags:
   - "open-source"
   - "rochester-institute-of-technology"
   - "teaching-open-source"
-coverImage: "github-organizations-for-clubs.png"
+images: ["/blog/2016/10/github-organizations-for-clubs.png"]
 ---
 
 For many universities and colleges, there are many technical clubs that students can join. Some clubs focus on programming or using programming for collaborative projects. For anything involving code, clubs usually turn to GitHub. GitHub has become the standard for open source project hosting by thousands of projects in the world. GitHub organizations are the tool GitHub provides to allow someone to create a team of people for working on projects. Organizations can have many repositories and smaller teams inside of them. When getting started with GitHub, there is a method to the madness, and there are ways you can have an ordered organization instead of keeping it messy. Here's how you do it.

--- a/content/blog/2016/10/virtual-meetup-wic-open-labs-foss-wave.md
+++ b/content/blog/2016/10/virtual-meetup-wic-open-labs-foss-wave.md
@@ -17,7 +17,7 @@ tags:
   - "rochester-institute-of-technology"
   - "teaching-open-source"
   - "women-in-computing-wic"
-coverImage: "virtual-meetup-wic-open-labs-foss-wave.png"
+images: ["/blog/2016/10/virtual-meetup-wic-open-labs-foss-wave.png"]
 ---
 
 Over the past year, I've met incredible people from around the world doing great things in their local communities. At my university, the [Women in Computing @ RIT](http://wic.rit.edu/) program provides networking for students with faculty, staff, and alumni. They also help advance women in computing through community outreach. I've also come into contact with two other international tech communities with interesting stories of their own. With the help of the [WiC events committee](http://wic.rit.edu/pages/committees.php), we are working on organizing a virtual meetup with WiC from New York, [Open Labs Albania](https://openlabs.cc/), and [FOSS Wave](http://landing.fosswave.com/) from India to introduce each other, share experiences, and more.

--- a/content/blog/2016/10/willful-winds.md
+++ b/content/blog/2016/10/willful-winds.md
@@ -7,7 +7,7 @@ tags:
   - "2010s"
   - "archives-journals"
   - "throwback-drafts"
-coverImage: "willful-winds.jpg"
+images: ["/blog/2016/10/willful-winds.jpg"]
 ---
 
 _This post is published as part of a personal archival project of [my poetry](https://jwfblog.wpenginepowered.com/category/poems/) and other creative works. The actual publish date of this post is Friday, April 19th, 2024, but the publish date of the post reflects the original date of authorship. This archival project aims to digitize a selection of written works that exist only in my private records. Enjoy._

--- a/content/blog/2016/11/spigotmc-california-minecon.md
+++ b/content/blog/2016/11/spigotmc-california-minecon.md
@@ -11,7 +11,7 @@ tags:
   - "minecraft"
   - "spigotmc"
   - "travel"
-coverImage: "spigotmc-california-minecon.jpg"
+images: ["/blog/2016/11/spigotmc-california-minecon.jpg"]
 ---
 
 Every year, [Mojang](http://mojang.com/) holds the annual [Minecraft](https://minecraft.net/en/) convention, MINECON. [MINECON](https://en.wikipedia.org/wiki/Minecon) is a convention where Minecraft players, software developers, content creators, and others in the Minecraft gaming world come together for a weekend of panels, activities, shows, and most importantly, comradery. I traveled to [Anaheim, California](https://en.wikipedia.org/wiki/Anaheim,_California) to see the [SpigotMC](https://www.spigotmc.org/) team again and help represent the open source cause. The convention was from September 24-25, 2016. This is my second time going to MINECON – [last year](https://jwfblog.wpenginepowered.com/2016/02/2015-year-review/), I went to London with the team as well.

--- a/content/blog/2017/02/2016-my-year-in-review.md
+++ b/content/blog/2017/02/2016-my-year-in-review.md
@@ -53,7 +53,7 @@ tags:
   - "women-in-computing-wic"
   - "wordpress"
   - "year-in-review"
-coverImage: "2016-year-in-review.jpg"
+images: ["/blog/2017/02/2016-year-in-review.jpg"]
 ---
 
 Before looking too far ahead to the future, it's important to spend time to reflect over the past year's events, identify successes and failures, and devise ways to improve. Describing my 2016 is a challenge for me to find the right words for. This post continues a habit I started last year with my [2015 Year in Review](https://jwfblog.wpenginepowered.com/2016/02/2015-year-review/). One thing I discover nearly every day is that I'm always learning new things from various people and circumstances. Even though 2017 is already getting started, I want to reflect back on some of these experiences and opportunities of the past year.

--- a/content/blog/2017/03/hackathon-albania-sustainable-goals.md
+++ b/content/blog/2017/03/hackathon-albania-sustainable-goals.md
@@ -18,7 +18,7 @@ tags:
   - "tirana-al"
   - "travel"
   - "united-nations"
-coverImage: "/img/BIZ_HighTrust_1110_A.png"
+images: ["/img/BIZ_HighTrust_1110_A.png"]
 ---
 
 [_This article was originally published on Opensource.com._](https://opensource.com/article/17/3/open-labs-48-hour-hackathon-albania)

--- a/content/blog/2017/04/fedora-diversity-fad-2017.md
+++ b/content/blog/2017/04/fedora-diversity-fad-2017.md
@@ -18,7 +18,7 @@ tags:
   - "fedora-planet"
   - "open-source-communities"
   - "travel"
-coverImage: "fedora-diversity-fad-2017.png"
+images: ["/blog/2017/04/fedora-diversity-fad-2017.png"]
 ---
 
 [_This article was originally published on the Fedora Community Blog._](https://communityblog.fedoraproject.org/fedora-diversity-fad-2017/)

--- a/content/blog/2017/04/happiness-packets-challenge.md
+++ b/content/blog/2017/04/happiness-packets-challenge.md
@@ -9,7 +9,7 @@ tags:
   - "friends"
   - "happiness-packets"
   - "open-source"
-coverImage: "/img/happiness-packet-challenge.png"
+images: ["/img/happiness-packet-challenge.png"]
 ---
 
 One of the most important lessons I was taught growing up is to say "thank you" when someone does something nice for you. Many months ago, someone first introduced me to something called [Happiness Packets](https://happinesspackets.io/). The idea is simple but powerfully effective. Happiness Packets are like thank-you cards for open source users or contributors. You can send a packet to anyone for anything. Your message can be as short or as long as you like. You can put your name on your message or you can keep it totally anonymous. The choice is yours. And now, **I want to challenge you to the #HappinessPacketChallenge**!

--- a/content/blog/2017/04/students-fedora-linux-weekend-2017.md
+++ b/content/blog/2017/04/students-fedora-linux-weekend-2017.md
@@ -22,7 +22,7 @@ tags:
   - "teaching-open-source"
   - "tirana-al"
   - "travel"
-coverImage: "ARP6625.jpg"
+images: ["/blog/2017/04/ARP6625.jpg"]
 ---
 
 _This article was originally published [on the Fedora Magazine](https://fedoramagazine.org/students-fedora-linux-weekend-2017/)._

--- a/content/blog/2017/07/famsco-august-2017-elections.md
+++ b/content/blog/2017/07/famsco-august-2017-elections.md
@@ -11,7 +11,7 @@ tags:
   - "fedora-planet"
   - "open-source-communities"
   - "working-together"
-coverImage: "/img/community.png"
+images: ["/img/community.png"]
 ---
 
 A new release of Fedora makes headlines this month. With every release, it also means a new round of the Fedora community leadership elections. On 24 July 2017, the [call for nominations](https://communityblog.fedoraproject.org/elections-august-2017-nomination-open/) went out for candidates. The [Fedora Engineering Steering Committee](https://fedoraproject.org/wiki/Fedora_Engineering_Steering_Committee) (FESCo), [Fedora Ambassador Steering Committee](https://fedoraproject.org/wiki/Fedora_Ambassadors_Steering_Committee) (FAmSCo), and the [Fedora Council](https://fedoraproject.org/wiki/Council) all have [seats open](https://fedoraproject.org/wiki/Elections). Already, discussions on nominations are happening. The candidate interview templates are [being prepared](https://pagure.io/fedora-commops/pull-request/113). Even now, the nomination lists are filling up. However, I want to share an opinion on the upcoming FAmSCo election specifically.

--- a/content/blog/2017/07/introduction-kubernetes-fedora.md
+++ b/content/blog/2017/07/introduction-kubernetes-fedora.md
@@ -16,7 +16,7 @@ tags:
   - "scalability"
   - "system-administration"
   - "things-you-should-know-understand"
-coverImage: "k8s-1-intro.jpg"
+images: ["/blog/2017/07/k8s-1-intro.jpg"]
 ---
 
 _**This article was originally published [on the Fedora Magazine](https://fedoramagazine.org/introduction-kubernetes-fedora/).**_

--- a/content/blog/2017/07/minikube-kubernetes.md
+++ b/content/blog/2017/07/minikube-kubernetes.md
@@ -14,7 +14,7 @@ tags:
   - "kubernetes"
   - "scalability"
   - "system-administration"
-coverImage: "k8s-2-minikube.jpg"
+images: ["/blog/2017/07/k8s-2-minikube.jpg"]
 ---
 
 _**This article was originally published [on the Fedora Magazine](https://fedoramagazine.org/minikube-kubernetes/).**_

--- a/content/blog/2017/07/ura-design-crowdfunds-design.md
+++ b/content/blog/2017/07/ura-design-crowdfunds-design.md
@@ -10,7 +10,7 @@ tags:
   - "open-source"
   - "open-source-communities"
   - "open-source-design"
-coverImage: "ura-design-osdc.png"
+images: ["/blog/2017/07/ura-design-osdc.png"]
 ---
 
 [_This article was originally published on Opensource.com._](https://opensource.com/article/17/6/ura-design-open-source-projects)

--- a/content/blog/2017/08/influxdb-time-series-database.md
+++ b/content/blog/2017/08/influxdb-time-series-database.md
@@ -15,7 +15,7 @@ tags:
   - "research-and-learning"
   - "things-you-should-know-understand"
   - "time-series-data"
-coverImage: "osdc_520x292_opendata_0613mm.png"
+images: ["/blog/2017/08/osdc_520x292_opendata_0613mm.png"]
 ---
 
 [_Article originally published on Opensource.com._](https://opensource.com/article/17/8/influxdb-time-series-database-stack)

--- a/content/blog/2017/08/riot-matrix-irc.md
+++ b/content/blog/2017/08/riot-matrix-irc.md
@@ -14,7 +14,7 @@ tags:
   - "messaging"
   - "open-source-communities"
   - "things-you-should-know-understand"
-coverImage: "riot-matrix-osdc.png"
+images: ["/blog/2017/08/riot-matrix-osdc.png"]
 ---
 
 [_This article was originally published on Opensource.com._](https://opensource.com/article/17/5/introducing-riot-IRC)

--- a/content/blog/2017/08/tirana-switches-nextcloud.md
+++ b/content/blog/2017/08/tirana-switches-nextcloud.md
@@ -12,7 +12,7 @@ tags:
   - "open-labs-albania"
   - "open-source"
   - "oscal-open-source-conference-albania"
-coverImage: "osdc_government_building_sky.jpg"
+images: ["/blog/2017/08/osdc_government_building_sky.jpg"]
 ---
 
 [_This article was originally published on Opensource.com._](https://opensource.com/article/17/8/tirana-government-chooses-open-source)

--- a/content/blog/2017/10/contributing-listenbrainz.md
+++ b/content/blog/2017/10/contributing-listenbrainz.md
@@ -17,7 +17,7 @@ tags:
   - "open-source"
   - "rit-2171"
   - "rochester-institute-of-technology"
-coverImage: "/img/listenbrainz-rit-independent-study.png"
+images: ["/img/listenbrainz-rit-independent-study.png"]
 ---
 
 A unique opportunity of attending an open source-friendly university is when course credits and working on open source projects collide. This semester, I'm participating in an independent study at the [Rochester Institute of Technology](https://www.rit.edu/) where I will contribute to the [ListenBrainz](https://listenbrainz.org/) project.

--- a/content/blog/2017/10/google-code-in-listenbrainz-d3-js.md
+++ b/content/blog/2017/10/google-code-in-listenbrainz-d3-js.md
@@ -20,7 +20,7 @@ tags:
   - "open-source"
   - "rit-2171"
   - "rochester-institute-of-technology"
-coverImage: "/img/listenbrainz-rit-independent-study.png"
+images: ["/img/listenbrainz-rit-independent-study.png"]
 ---
 
 _This post is part of a series of posts where I contribute to the ListenBrainz project for my independent study at the Rochester Institute of Technology in the fall 2017 semester. For more posts, find them in [this tag](https://jwfblog.wpenginepowered.com/tag/rit-2171/)._

--- a/content/blog/2017/10/listenbrainz-development-environment.md
+++ b/content/blog/2017/10/listenbrainz-development-environment.md
@@ -20,7 +20,7 @@ tags:
   - "open-source"
   - "rit-2171"
   - "rochester-institute-of-technology"
-coverImage: "/img/listenbrainz-rit-independent-study.png"
+images: ["/img/listenbrainz-rit-independent-study.png"]
 ---
 
 _This post is part of a series of posts where I contribute to the ListenBrainz project for my independent study at the Rochester Institute of Technology in the fall 2017 semester. For more posts, find them in [this tag](https://jwfblog.wpenginepowered.com/tag/rit-2171/)._

--- a/content/blog/2017/10/resigning-fedora-council.md
+++ b/content/blog/2017/10/resigning-fedora-council.md
@@ -10,7 +10,7 @@ tags:
   - "fedora"
   - "fedora-planet"
   - "open-source-communities"
-coverImage: "/img/community.png"
+images: ["/img/community.png"]
 ---
 
 Since I became a Fedora contributor in August 2015, I've spent a lot of time in the community. One of the great things about a big community like Fedora is that there are several different things to try out. I've always tried to do the most help in Fedora with my contributions. I prefer to make long-term, in-depth contributions than short-term, "quick fix"-style work. However, like many others, Fedora is a project I contribute to in my free time. Over the last month, I've come to a difficult realization.

--- a/content/blog/2017/11/first-rpm-package-fedora.md
+++ b/content/blog/2017/11/first-rpm-package-fedora.md
@@ -11,7 +11,7 @@ tags:
   - "open-source"
   - "packaging"
   - "rpm"
-coverImage: "newpackage.png"
+images: ["/blog/2017/11/newpackage.png"]
 ---
 
 Over the summer, I migrated my desktop environment to [i3](https://i3wm.org/), a tiling window manager. Switching to i3 was a challenge at first, since I had to replace many things that GNOME handled for me. One of these things was changing screen brightness. `xbacklight`, the standard way of changing backlight brightness on laptops, doesn't work on my hardware.

--- a/content/blog/2017/11/how-smart-phone-time-irrelevant.md
+++ b/content/blog/2017/11/how-smart-phone-time-irrelevant.md
@@ -8,7 +8,7 @@ tags:
   - "fedora-planet"
   - "life-lessons"
   - "reflections"
-coverImage: "smart-phone-time-irrelevant.png"
+images: ["/blog/2017/11/smart-phone-time-irrelevant.png"]
 ---
 
 It’s 2pm in the afternoon and the weather is becoming cold after so long. On this brisk November day, an old professor steps out in the corner lobby of the college. The golden rays of the sun cast a warm, radiant glow, leaving a bright, inviting air. This small moment of time is meaningless in an infinite universe of possible moments.

--- a/content/blog/2017/11/listenbrainz-community-user-statistics.md
+++ b/content/blog/2017/11/listenbrainz-community-user-statistics.md
@@ -21,7 +21,7 @@ tags:
   - "rit-2171"
   - "rochester-institute-of-technology"
   - "selinux"
-coverImage: "/img/listenbrainz-rit-independent-study.png"
+images: ["/img/listenbrainz-rit-independent-study.png"]
 ---
 
 _This post is part of a series of posts where I contribute to the ListenBrainz project for my independent study at the Rochester Institute of Technology in the fall 2017 semester. For more posts, find them in [this tag](https://jwfblog.wpenginepowered.com/tag/rit-2171/)._

--- a/content/blog/2017/12/election-night-hackathon.md
+++ b/content/blog/2017/12/election-night-hackathon.md
@@ -13,7 +13,7 @@ tags:
   - "open-source-communities"
   - "rochester-institute-of-technology"
   - "university"
-coverImage: "GOV_citizen_participation.jpg"
+images: ["/blog/2017/12/GOV_citizen_participation.jpg"]
 ---
 
 [_This article was originally published on Opensource.com._](https://opensource.com/article/17/12/rit-election-night-hackathon)

--- a/content/blog/2017/12/statistics-hosting-listenbrainz.md
+++ b/content/blog/2017/12/statistics-hosting-listenbrainz.md
@@ -20,7 +20,7 @@ tags:
   - "reflections"
   - "rit-2171"
   - "rochester-institute-of-technology"
-coverImage: "/img/listenbrainz-rit-independent-study.png"
+images: ["/img/listenbrainz-rit-independent-study.png"]
 ---
 
 _This post is part of a series of posts where I contribute to the ListenBrainz project for my independent study at the Rochester Institute of Technology in the fall 2017 semester. For more posts, find them in [this tag](https://jwfblog.wpenginepowered.com/tag/rit-2171/)._

--- a/content/blog/2017/12/tergiversate-music-review.md
+++ b/content/blog/2017/12/tergiversate-music-review.md
@@ -8,7 +8,7 @@ tags:
   - "music"
   - "music-review"
   - "tergiversate-music-column"
-coverImage: "tergiversate-music-column.png"
+images: ["/blog/2017/12/tergiversate-music-column.png"]
 ---
 
 Music is a key part of my life. I spend a lot of time listening and analyzing music. However, music is as much a personal experience as it is a social one too. In music, an artist shares their perspective and experience with the listener. The listener, in turn, shares music with others. In my experience, some of the best music recommendations have come from friends or from other music fans. Thus, I'm happy to announce **Tergiversate**, a new column on my blog that celebrates great music and the role it plays in documenting culture and society.

--- a/content/blog/2018/01/demon-days-gorillaz.md
+++ b/content/blog/2018/01/demon-days-gorillaz.md
@@ -11,7 +11,7 @@ tags:
   - "music"
   - "music-review"
   - "tergiversate-music-column"
-coverImage: "tergiversate-demon-days-gorillaz.jpg"
+images: ["/blog/2018/01/tergiversate-demon-days-gorillaz.jpg"]
 ---
 
 The first album to début in my [Tergiversate music column](https://jwfblog.wpenginepowered.com/tag/tergiversate-music-column/) isn't a new album, but it's an album with a meaning that evolves and changes over time into something new. [_Demon Days_](https://en.wikipedia.org/wiki/Demon_Days) is the second studio album released by [Gorillaz](https://en.wikipedia.org/wiki/Gorillaz) in 2005. _Demon Days_ is officially classified as alternative hip hop, but it's better described as a fusion of styles and genres, rolled together. Some tracks hang true to the underground hip hop sounds from the first album, others to a pop-ish sound found in their third album, and others are completely unique to _Demon Days_.

--- a/content/blog/2018/01/fedora-2017-year-review.md
+++ b/content/blog/2018/01/fedora-2017-year-review.md
@@ -11,7 +11,7 @@ tags:
   - "fedora-planet"
   - "open-source-communities"
   - "retrospective"
-coverImage: "fedora-year-in-review-coming-soon.jpg"
+images: ["/blog/2018/01/fedora-year-in-review-coming-soon.jpg"]
 ---
 
 The past year was a busy for Fedora. The community released Fedora 26 and 27. Different sub-projects of Fedora give their share of time for the overall success of Fedora. But in a project as big as Fedora, it's hard to keep track of what everyone is doing! If you're a developer, you likely know more about what's happening inside the code of Fedora, but you may not know what's happening with the Fedora Ambassadors. Or maybe you're involved with Globalization (G11n) and translating and know what's happening there, but you're not as familiar with what the Fedora Design team is working on.

--- a/content/blog/2018/02/2017-year-review.md
+++ b/content/blog/2018/02/2017-year-review.md
@@ -54,7 +54,7 @@ tags:
   - "unicef"
   - "united-nations"
   - "year-in-review"
-coverImage: "2017-year-review.jpg"
+images: ["/blog/2018/02/2017-year-review.jpg"]
 ---
 
 I can't remember how [writing an annual reflection](https://jwfblog.wpenginepowered.com/tag/year-in-review/) became a tradition, but after writing them for the last two years, it is now a habit. Every time I look back on all that the last year brought into my life, it is surreal. Many things that happened, I could never have expected one or two years ago. And perhaps now, I see that life is defined by the unexpected moments: the things that surprise us, warm our hearts, sadden us, and remind us of our humanity. Thus, I present my year in review of 2017.

--- a/content/blog/2018/02/facebook-open-source-program.md
+++ b/content/blog/2018/02/facebook-open-source-program.md
@@ -12,7 +12,7 @@ tags:
   - "rochester-institute-of-technology"
   - "social-media"
   - "teaching-open-source"
-coverImage: "LAW-Internet_construction_9401467_520x292_0512_dc.png"
+images: ["/blog/2018/02/LAW-Internet_construction_9401467_520x292_0512_dc.png"]
 ---
 
 [_Originally published on Opensource.com._](https://opensource.com/article/18/1/inside-facebooks-open-source-program)

--- a/content/blog/2018/02/unicef-internship.md
+++ b/content/blog/2018/02/unicef-internship.md
@@ -14,7 +14,7 @@ tags:
   - "unicef-internship-2018"
   - "united-nations"
   - "working-together"
-coverImage: "unicef-opensource.png"
+images: ["/blog/2018/02/unicef-opensource.png"]
 ---
 
 In December, I received the happy news of an offer for a internship position at [UNICEF](https://www.unicef.org/what-we-do) in the Office of Innovation. The [Office of Innovation](http://unicefstories.org/about/) drives rapid technological innovation by rapid prototyping of new ideas and building full-stack products to make a positive impact in the lives of children. This is a simple answer, but a more detailed description is [on our website](http://unicefstories.org/about/).

--- a/content/blog/2018/03/abysma-geotic.md
+++ b/content/blog/2018/03/abysma-geotic.md
@@ -12,7 +12,7 @@ tags:
   - "music"
   - "music-review"
   - "tergiversate-music-column"
-coverImage: "tergiversate-abysma-geotic.png"
+images: ["/blog/2018/03/tergiversate-abysma-geotic.png"]
 ---
 
 _This article is part of my [Tervigersate column](https://jwfblog.wpenginepowered.com/tag/tergiversate-music-column/) on my blog, where I review albums by musicians spanning multiple genres. Articles introduce an album and give my interpretation of their meaning._

--- a/content/blog/2018/04/3-things-learned-deleting-facebook.md
+++ b/content/blog/2018/04/3-things-learned-deleting-facebook.md
@@ -12,7 +12,7 @@ tags:
   - "life-lessons"
   - "reflections"
   - "social-media"
-coverImage: "3-things-learned-deleting-facebook.png"
+images: ["/blog/2018/04/3-things-learned-deleting-facebook.png"]
 ---
 
 Six months ago, I deleted my Facebook and Instagram accounts. Beyond data privacy concerns, social media became a virtual band-aid applied to moments of weakness and sadness for me. I became more aware of the effects of social media on my mood and general outlook on the world, as I explained in my decision to [delete my accounts](https://medium.com/@jflory7/cut-the-plug-deleting-facebook-and-instagram-6cbe7c86d9c9). Six months now passed since I deleted my accounts. Along the way, I learned a few lessons on creating a healthy diet of media and pop culture consumption in a world of constant connectivity and endless memes.

--- a/content/blog/2018/10/five-queen-songs-mainstream.md
+++ b/content/blog/2018/10/five-queen-songs-mainstream.md
@@ -16,7 +16,7 @@ tags:
   - "musicbrainz"
   - "rochester-institute-of-technology"
   - "rochester-ny-usa"
-coverImage: "five-queen-songs-mainstream.jpg"
+images: ["/blog/2018/10/five-queen-songs-mainstream.jpg"]
 ---
 
 [_Originally published on the MusicBrainz blog._](http://blog.musicbrainz.org/2018/10/16/five-queen-songs-mainstream/)

--- a/content/blog/2018/10/wikipedia-privilege.md
+++ b/content/blog/2018/10/wikipedia-privilege.md
@@ -11,7 +11,7 @@ tags:
   - "opinion"
   - "privilege"
   - "wikipedia"
-coverImage: "wikipedia-privilege.jpg"
+images: ["/blog/2018/10/wikipedia-privilege.jpg"]
 ---
 
 _Originally written as an essay response for [ENGL-450 Free and Open Source Culture](https://www.rit.edu/cla/english/450-free-and-open-source-culture) at the [Rochester Institute of Technology](https://www.rit.edu/)._

--- a/content/blog/2018/11/sustain-oss-2018-quick-rewind.md
+++ b/content/blog/2018/11/sustain-oss-2018-quick-rewind.md
@@ -20,7 +20,7 @@ tags:
   - "sustain-oss"
   - "teaching-open-source"
   - "university"
-coverImage: "sustain-oss-2018.png"
+images: ["/blog/2018/11/sustain-oss-2018.png"]
 ---
 
 This year, I attended the second edition of the [Sustain Open Source Summit](https://sustainoss.org/) (a.k.a. Sustain OSS) on October 25th, 2018 in London. Sustain OSS is a one-day discussion on various topics about sustainability in open source ecosystems. It's also a collection of diverse roles across the world of open source. From small project maintainers to open source program managers at the largest tech companies in the world, designers to government employees, there is a mix of backgrounds in the room. Yet there is a shared context around the most systemic problems faced by open source projects, communities, and people around the world.

--- a/content/blog/2018/12/meet-an-opinionated-quickstart-for-sphinx-docs-authors.md
+++ b/content/blog/2018/12/meet-an-opinionated-quickstart-for-sphinx-docs-authors.md
@@ -14,7 +14,7 @@ tags:
   - "rit-linux-users-group-ritlug"
   - "rochester-institute-of-technology"
   - "sphinx"
-coverImage: "sphinx-docs-opinionated-quickstart.jpg"
+images: ["/blog/2018/12/sphinx-docs-opinionated-quickstart.jpg"]
 ---
 
 Do you write documentation with the Sphinx [tool chain](http://www.sphinx-doc.org/en/master/)? Do you want to encourage more people to write Sphinx documentation in a distributed organization, but worry about maintaining compatible workflows? Introducing [sphinx-docs-opinionated-quickstart](https://github.com/justwheel/sphinx-docs-opinionated-quickstart), a template repository with an opinionated configuration of ReStructuredText documentation with Travis CI testing and [readthedocs.org](https://readthedocs.org/) publishing.  

--- a/content/blog/2019/02/teleirc-v1-3-next-release.md
+++ b/content/blog/2019/02/teleirc-v1-3-next-release.md
@@ -17,7 +17,7 @@ tags:
   - "telegram"
   - "teleirc"
   - "upstream"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 On Saturday, February 2nd, 2019, the [TeleIRC](https://github.com/RITlug/teleirc) community in Rochester, NY held the first developers' meeting. Starting this month, weekly meetings are held to discuss blocking issues and plan ahead for the future of the project. Current project lead [Justin Wheeler](https://jwheel.org/) met with [Tim Zabel](https://github.com/Tjzabel) and [Nic Hartley](https://github.com/nic-hartley/) to finish planning the v1.3 milestone for TeleIRC. Notably, this marks the next feature-release of TeleIRC since v1.2 in October 2018.

--- a/content/blog/2019/03/teleirc-roadmap-v1-4.md
+++ b/content/blog/2019/03/teleirc-roadmap-v1-4.md
@@ -18,7 +18,7 @@ tags:
   - "telegram"
   - "teleirc"
   - "upstream"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 The [RITlug](https://ritlug.com/) TeleIRC developer team celebrated the [v1.3 release](https://github.com/RITlug/teleirc/releases/tag/v1.3) on March 3rd, 2019. Looking ahead, the team is mapping out next steps for quality-of-life improvements in v1.4.

--- a/content/blog/2019/04/teleirc-v1-3-1-released.md
+++ b/content/blog/2019/04/teleirc-v1-3-1-released.md
@@ -18,7 +18,7 @@ tags:
   - "telegram"
   - "teleirc"
   - "upstream"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 On April 20th, 2019, the TeleIRC development team [released TeleIRC v1.3.1](https://github.com/RITlug/teleirc/releases/tag/v1.3.1), the latest version after the final development sprint for the university semester. This release introduces minor improvements in order to accommodate heavier work-balance loads on our volunteer contributors. However, it gave us an opportunity to reduce technical debt. This blog post explains what's new in TeleIRC v1.3.1 and also offers a retrospective into how this last sprint went.

--- a/content/blog/2019/05/ehlers-danlos-syndrome.md
+++ b/content/blog/2019/05/ehlers-danlos-syndrome.md
@@ -7,7 +7,7 @@ tags:
   - "ehlers-danlos"
   - "health"
   - "invisible-illness"
-coverImage: "ehler-danlos-syndrome.png"
+images: ["/blog/2019/05/ehler-danlos-syndrome.png"]
 ---
 
 May is [Ehlers-Danlos Syndrome Awareness Month](https://ehlers-danlos.com/dazzle/). Ehlers-Danlos Syndrome, abbreviated as EDS, is a genetic disorder that affects [1 out of 5,000 people](https://ghr.nlm.nih.gov/condition/ehlers-danlos-syndrome#statistics) across the world. It is considered an "invisible illness" since its symptoms are not always visible to the eye.

--- a/content/blog/2019/06/markdown-accessible-images.md
+++ b/content/blog/2019/06/markdown-accessible-images.md
@@ -14,7 +14,7 @@ tags:
   - "fedora-planet"
   - "things-you-should-know-understand"
   - "writing"
-coverImage: "markdown-accessible-text-one-simple-trick.jpg"
+images: ["/blog/2019/06/markdown-accessible-text-one-simple-trick.jpg"]
 ---
 
 Sometimes the people we exclude are the ones we did not realize were there. [Screen readers](https://en.wikipedia.org/wiki/Screen_reader) are an essential tool for blind and visually-impaired people to use software and browse the Internet. In open source projects and communities, Markdown is a [lightweight markup language](https://en.wikipedia.org/wiki/Markdown) used to format text. It is also used in many other places. Often you need to embed an image into whatever you are writing (a picture, a diagram, or some useful visual aid to get your point across). One of the lesser-known and used features of Markdown are **alt tags for images**.

--- a/content/blog/2019/08/hpc-workloads-containers.md
+++ b/content/blog/2019/08/hpc-workloads-containers.md
@@ -13,7 +13,7 @@ tags:
   - "open-source"
   - "open-source-communities"
   - "research-and-learning"
-coverImage: "hpc-workloads-containers.jpg"
+images: ["/blog/2019/08/hpc-workloads-containers.jpg"]
 ---
 
 Recently, I worked on an interesting project to evaluate different container run-times for high-performance computing (HPC) clusters. HPC clusters are what we once knew as [supercomputers](https://en.wikipedia.org/wiki/Supercomputer). Today, instead of giant mainframes, they are hundreds, thousands, or tens of thousands of [massively parallel](https://en.wikipedia.org/wiki/Massively_parallel) systems. Since performance is critical, virtualization with tools like virtual machines or Docker containers was not realistic. The overhead was too much compared to bare metal.

--- a/content/blog/2019/12/why-foss-is-still-not-on-activist-agendas.md
+++ b/content/blog/2019/12/why-foss-is-still-not-on-activist-agendas.md
@@ -31,7 +31,7 @@ tags:
   - "unicef"
   - "what-its-all-about"
   - "working-together"
-coverImage: "why-foss-still-not-on-activist-agendas.jpg"
+images: ["/blog/2019/12/why-foss-still-not-on-activist-agendas.jpg"]
 ---
 
 On December 13th, 2006, author [Bruce Byfield](https://en.wikipedia.org/wiki/Bruce_Byfield) reflected on why he thought Free and Open Source Software (F.O.S.S.) was [not on activist agendas](https://web.archive.org/web/20191130172436/https://www.linux.com/news/why-foss-isnt-activist-agendas/). My interpretation of his views are that a knowledge barrier about technology makes FOSS less accessible, the insular nature of activism makes collaboration difficult, and FOSS activists reaching out to other activists with shared values should be encouraged. On December 13th, 2019, is FOSS on activist agendas? The answer is not black or white, but a gray somewhere in the middle. This is my response to Byfield's article, thirteen years later, on what he got right but also what he left out.

--- a/content/blog/2020/02/chaosscon-eu-2020-play-by-play.md
+++ b/content/blog/2020/02/chaosscon-eu-2020-play-by-play.md
@@ -24,7 +24,7 @@ tags:
   - "open-source-communities"
   - "rochester-institute-of-technology"
   - "travel"
-coverImage: "chaosscon-eu-2020.png"
+images: ["/blog/2020/02/chaosscon-eu-2020.png"]
 ---
 
 CHAOSScon EU 2020 took place on Friday, 31 January, 2020 in Brussels, Belgium (the day after [Sustain OSS 2020](https://jwfblog.wpenginepowered.com/2020/02/sustain-oss-2020-quick-rewind/)):

--- a/content/blog/2020/02/devconf-cz-2020-play-by-play.md
+++ b/content/blog/2020/02/devconf-cz-2020-play-by-play.md
@@ -24,7 +24,7 @@ tags:
   - "metrics"
   - "open-source-communities"
   - "rochester-institute-of-technology"
-coverImage: "devconf-2020.png"
+images: ["/blog/2020/02/devconf-2020.png"]
 ---
 
 DevConf CZ 2020 took place from Friday, January 24th to Sunday January 27th in Brno, Czech Republic:

--- a/content/blog/2020/02/sustain-oss-2020-quick-rewind.md
+++ b/content/blog/2020/02/sustain-oss-2020-quick-rewind.md
@@ -22,7 +22,7 @@ tags:
   - "sustain-oss"
   - "travel"
   - "working-together"
-coverImage: "sustain-oss-2020.png"
+images: ["/blog/2020/02/sustain-oss-2020.png"]
 ---
 
 The **2020 Sustain Open Source Summit** took place on Thursday, 30 January, 2020 in Brussels, Belgium:

--- a/content/blog/2020/03/fosdem-2020-pt-1-play-by-play.md
+++ b/content/blog/2020/03/fosdem-2020-pt-1-play-by-play.md
@@ -20,7 +20,7 @@ tags:
   - "open-source-design"
   - "rochester-institute-of-technology"
   - "travel"
-coverImage: "/img/fosdem-2020.png"
+images: ["/img/fosdem-2020.png"]
 ---
 
 FOSDEM 2020 took place from Saturday, 1 February, 2020 to Sunday, 2 February, 2020 in Brussels, Belgium (shortly after [Sustain OSS 2020](https://jwfblog.wpenginepowered.com/2020/02/sustain-oss-2020-quick-rewind/) and [CHAOSScon EU 2020](https://jwfblog.wpenginepowered.com/2020/02/chaosscon-eu-2020-play-by-play/)):

--- a/content/blog/2020/03/teleirc-v2-0-0-march-2020-progress-update.md
+++ b/content/blog/2020/03/teleirc-v2-0-0-march-2020-progress-update.md
@@ -20,7 +20,7 @@ tags:
   - "teleirc"
   - "upstream"
   - "working-together"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 Since September 2019, the [RITlug](https://ritlug.com/) TeleIRC team is hard at work on the [v2.0.0 release](https://github.com/RITlug/teleirc/milestone/8) of TeleIRC. This blog post is a short update on what is coming in TeleIRC v2.0.0, our progress so far, and when to expect the next major release.

--- a/content/blog/2020/04/2020-happiness-packets-challenge.md
+++ b/content/blog/2020/04/2020-happiness-packets-challenge.md
@@ -10,7 +10,7 @@ tags:
   - "happiness-packets"
   - "open-source"
   - "what-its-all-about"
-coverImage: "/img/happiness-packet-challenge.png"
+images: ["/img/happiness-packet-challenge.png"]
 ---
 
 In this brave new COVID-19 world, we have to watch out for each other. These times are unusual and not normal. This year in 2020, **I challenge you to join me and others in the Happiness Packets Challenge from Monday, 27 April to Sunday, 3 May**! This is the same challenge I made [in 2017](https://jwfblog.wpenginepowered.com/2017/04/happiness-packets-challenge/). Can you say thanks to someone different every day for one week?

--- a/content/blog/2020/04/copyleftconf-2020-quick-rewind.md
+++ b/content/blog/2020/04/copyleftconf-2020-quick-rewind.md
@@ -24,7 +24,7 @@ tags:
   - "reflections"
   - "travel"
   - "what-its-all-about"
-coverImage: "copyleftconf-2020-1.png"
+images: ["/blog/2020/04/copyleftconf-2020-1.png"]
 ---
 
 **CopyleftConf 2020** took place on Monday, 3 February, 2020 in Brussels, Belgium:

--- a/content/blog/2020/04/fosdem-2020-pt-2-can-free-software-include-ethical-ai-systems.md
+++ b/content/blog/2020/04/fosdem-2020-pt-2-can-free-software-include-ethical-ai-systems.md
@@ -17,7 +17,7 @@ tags:
   - "librecorps"
   - "open-source"
   - "travel"
-coverImage: "/img/fosdem-2020.png"
+images: ["/img/fosdem-2020.png"]
 ---
 
 _This post is a follow-up to [FOSDEM 2020, pt. 1: Play by play](https://jwfblog.wpenginepowered.com/2020/03/fosdem-2020-pt-1-play-by-play/). This post summarizes the talk given by me and my colleague, [Mike Nolan](https://nolski.rocks/), at FOSDEM 2020._

--- a/content/blog/2020/04/how-did-free-software-build-a-social-movement.md
+++ b/content/blog/2020/04/how-did-free-software-build-a-social-movement.md
@@ -22,7 +22,7 @@ tags:
   - "reflections"
   - "things-you-should-know-understand"
   - "working-together"
-coverImage: "free-software-social-movement.png"
+images: ["/blog/2020/04/free-software-social-movement.png"]
 ---
 
 The Free Software movement is rooted to origins in the 1980s. As part of a talk I gave with my colleague and friend Mike Nolan [at FOSDEM 2020](https://jwfblog.wpenginepowered.com/2020/04/fosdem-2020-pt-2-can-free-software-include-ethical-ai-systems/), we analyzed how the Free Software movement emerged as a response to a changing digital world in three different phases. This blog post is an exploration and framing of that history to understand how the social movement we call "Free Software" was constructed.

--- a/content/blog/2020/04/open-source-minecraft-bukkit-gpl.md
+++ b/content/blog/2020/04/open-source-minecraft-bukkit-gpl.md
@@ -14,7 +14,7 @@ tags:
   - "open-source-communities"
   - "open-source-licenses"
   - "rochester-institute-of-technology"
-coverImage: "open-source-minecraft-bukkit-gpl.png"
+images: ["/blog/2020/04/open-source-minecraft-bukkit-gpl.png"]
 ---
 
 Once upon a time, when I was a teenager, I volunteered in the Minecraft open source community. I volunteered as a staff member of the largest open source Minecraft server today, called [Spigot](https://www.spigotmc.org/wiki/about-spigot/). Spigot is a fork of the Bukkit project.

--- a/content/blog/2020/05/teleirc-v2-0-0-is-officially-here.md
+++ b/content/blog/2020/05/teleirc-v2-0-0-is-officially-here.md
@@ -16,7 +16,7 @@ tags:
   - "teleirc"
   - "upstream"
   - "working-together"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 After almost eight months of work, the TeleIRC Team is happy to announce **General Availability of TeleIRC v2.0.0 today**. Thanks to the hard work of our volunteer community, we are celebrating an on-time release of a major undertaking to make a more sustainable future for TeleIRC.

--- a/content/blog/2020/05/whats-new-in-teleirc-v2-0-0.md
+++ b/content/blog/2020/05/whats-new-in-teleirc-v2-0-0.md
@@ -18,7 +18,7 @@ tags:
   - "teleirc"
   - "upstream"
   - "working-together"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 TeleIRC v2.0.0 is the latest major release of our open source Telegram <=> IRC bridge. Download the [latest release](https://github.com/RITlug/teleirc/releases/tag/v2.0.0) and read the [release announcement](https://jwfblog.wpenginepowered.com/2020/05/teleirc-v2-0-0-is-officially-here/) for the full story.

--- a/content/blog/2020/06/facilitation-collaboration-principles-authentic-participation.md
+++ b/content/blog/2020/06/facilitation-collaboration-principles-authentic-participation.md
@@ -20,7 +20,7 @@ tags:
   - "things-you-should-know-understand"
   - "upstream"
   - "working-together"
-coverImage: "/img/BIZ_HighTrust_1110_A.png"
+images: ["/img/BIZ_HighTrust_1110_A.png"]
 ---
 
 This is the story about the facilitation of the [Principles of Authentic Participation](https://authentic-participation.readthedocs.io/).

--- a/content/blog/2020/09/a-reflection-gabriele-trombini-mailga.md
+++ b/content/blog/2020/09/a-reflection-gabriele-trombini-mailga.md
@@ -11,7 +11,7 @@ tags:
   - "friends"
   - "reflections"
   - "what-its-all-about"
-coverImage: "IMG_20180304_123446-scaled.jpg"
+images: ["/blog/2020/09/IMG_20180304_123446-scaled.jpg"]
 ---
 
 _Trigger warning: Grief, death._

--- a/content/blog/2020/09/tergiversate-el-ten-eleven.md
+++ b/content/blog/2020/09/tergiversate-el-ten-eleven.md
@@ -11,7 +11,7 @@ tags:
   - "post-rock"
   - "reflections"
   - "tergiversate-music-column"
-coverImage: "tergiversate-el-ten-eleven-self-titled.png"
+images: ["/blog/2020/09/tergiversate-el-ten-eleven-self-titled.png"]
 ---
 
 _This El Ten Eleven article is part of my [Tervigersate column](https://jwfblog.wpenginepowered.com/tag/tergiversate-music-column/) on my blog, where I review albums by musicians spanning multiple genres. Articles introduce an album and give my interpretation of their meaning._

--- a/content/blog/2020/10/cryptographic-autonomy-license-cal-1-0.md
+++ b/content/blog/2020/10/cryptographic-autonomy-license-cal-1-0.md
@@ -12,7 +12,7 @@ tags:
   - "open-source-licenses"
   - "opinion"
   - "teaching-open-source"
-coverImage: "cryptographic-autonomy-license.jpg"
+images: ["/blog/2020/10/cryptographic-autonomy-license.jpg"]
 ---
 
 The bookmark was creeping on my browser's toolbar for months. "Cryptographic Autonomy License" CAL-1.0 on the [Open Source Initiative webpage](https://opensource.org/licenses/CAL-1.0). But today, I decided it was time to do my first amateur license review. This is a fun exercise (for me). Remember, **I am not a lawyer and this does not constitute legal advice**!

--- a/content/blog/2020/10/hacktoberfest-2020-with-teleirc.md
+++ b/content/blog/2020/10/hacktoberfest-2020-with-teleirc.md
@@ -15,7 +15,7 @@ tags:
   - "open-source-communities"
   - "telegram"
   - "teleirc"
-coverImage: "/img/teleirc-development-update.jpg"
+images: ["/img/teleirc-development-update.jpg"]
 ---
 
 October is here! If you contribute to Open Source projects, you might know that October is the month of Hacktoberfest. [DigitalOcean teams up](https://hacktoberfest.digitalocean.com/) with different partners each year to send a t-shirt (or plant a tree on your behalf) for anyone who makes four GitHub Pull Requests in October. And guess what? TeleIRC is a participating project for you to get your Hacktoberfest t-shirt or tree!

--- a/content/blog/2020/12/three-predictions-for-free-software-in-the-2020s.md
+++ b/content/blog/2020/12/three-predictions-for-free-software-in-the-2020s.md
@@ -16,7 +16,7 @@ tags:
   - "reflections"
   - "rochester-institute-of-technology"
   - "sustainability"
-coverImage: "three-predictions-free-software-2020s.png"
+images: ["/blog/2020/12/three-predictions-free-software-2020s.png"]
 ---
 
 From January to May 2020, I completed an independent study at the [Rochester Institute of Technology](https://www.rit.edu/) on _Business and Legal Aspects of Free/Open Source Software_. This was the final credit for my completion of the [Free and Open Source Software and Free Culture](https://www.rit.edu/study/free-and-open-source-software-and-free-culture-minor) minor.

--- a/content/blog/2021/04/2021-osi-board-of-directors-statement-of-intent.md
+++ b/content/blog/2021/04/2021-osi-board-of-directors-statement-of-intent.md
@@ -14,7 +14,7 @@ tags:
   - "open-source-licenses"
   - "reflections"
   - "what-its-all-about"
-coverImage: "osi-statement-intent.jpg"
+images: ["/blog/2021/04/osi-statement-intent.jpg"]
 ---
 
 _This first appeared [on the Open Source Initiative Wiki](https://wiki.opensource.org/bin/Main/OSI%20Board%20of%20Directors/Board%20Member%20Elections/2021%20Individual%20and%20Affiliate%20Elections/Flory2021/). In light of the [election update this year](https://opensource.org/election_update), I am republishing my statement of intent on my personal blog._

--- a/content/blog/2021/07/unicef-open-source-mentorship.md
+++ b/content/blog/2021/07/unicef-open-source-mentorship.md
@@ -18,7 +18,7 @@ tags:
   - "teaching-open-source"
   - "unicef"
   - "united-nations"
-coverImage: "/img/unicef-open-source-mentorship-programme.png"
+images: ["/img/unicef-open-source-mentorship-programme.png"]
 ---
 
 _This post was co-published [on the UNICEF Innovation Fund blog](https://www.unicefinnovationfund.org/broadcast/expert-posts/introducing-unicef-open-source-mentorship)._

--- a/content/blog/2021/08/a-proposal-for-the-end-of-accommodations.md
+++ b/content/blog/2021/08/a-proposal-for-the-end-of-accommodations.md
@@ -17,7 +17,7 @@ tags:
   - "reflections"
   - "things-you-should-know-understand"
   - "working-together"
-coverImage: "end-of-accommodations.jpg"
+images: ["/blog/2021/08/end-of-accommodations.jpg"]
 ---
 
 Language is powerful. Words are subtle building blocks to how we imagine the world around us. So, with the goal of pursuing more equitable language, I propose the end of accommodations.

--- a/content/blog/2021/08/open-source-dependencies.md
+++ b/content/blog/2021/08/open-source-dependencies.md
@@ -16,7 +16,7 @@ tags:
   - "open-source-licenses"
   - "politics"
   - "reflections"
-coverImage: "open-source-dependencies.png"
+images: ["/blog/2021/08/open-source-dependencies.png"]
 ---
 
 I often wonder how to best measure and communicate Open Source value. The collective focus of the industry goes into quantifying dependencies; that is, how one software relies on other software in order to complete its primary function. The vocabulary to measure dependency usually includes words like "imports," "licenses," "bugs fixed to bugs open," and other machine-oriented terms. Yet the unique value proposition of _innovative_ Open Source involves a community of people around a software. This led me on to the next question: **why do we bias towards machine-oriented terms instead of human-oriented or community-oriented terms to describe Open Source communities and division of labor?**

--- a/content/blog/2021/08/pershendetje-tirane.md
+++ b/content/blog/2021/08/pershendetje-tirane.md
@@ -16,7 +16,7 @@ tags:
   - "summer-activities"
   - "tirana-al"
   - "travel"
-coverImage: "pershendetje-tirane.jpg"
+images: ["/blog/2021/08/pershendetje-tirane.jpg"]
 ---
 
 Përshëndetje nga Tiranë, or in Albanian, hello from Tirana! I am residing for a short time in Tiranë (pronounced Ti·ra·na), [Albania](https://en.wikipedia.org/wiki/Albania). After a previous visit in June, I decided to make Tiranë my home for part of my remote work contract. I moved in this past week.

--- a/content/blog/2021/09/2020-2021-in-open-source-at-unicef-innovation-fund.md
+++ b/content/blog/2021/09/2020-2021-in-open-source-at-unicef-innovation-fund.md
@@ -15,7 +15,7 @@ tags:
   - "teaching-open-source"
   - "unicef"
   - "united-nations"
-coverImage: "/img/unicef-open-source-mentorship-programme.png"
+images: ["/img/unicef-open-source-mentorship-programme.png"]
 ---
 
 Open Source is a means to collaborate and solve common problems; during the COVID-19 pandemic, open data and tools [proved useful](https://www.dlapiper.com/en/us/insights/publications/2021/07/techlaw-podcast-sesg-venture-capital-for-good-and-software-solutions-with-a-purpose) in quickly tailoring and deploying life-saving services. How has the [UNICEF Innovation Fund](https://www.unicef.org/innovation/) kept up with latest Open Source innovations?

--- a/content/blog/2021/10/red-hat-iran.md
+++ b/content/blog/2021/10/red-hat-iran.md
@@ -19,7 +19,7 @@ tags:
   - "open-source"
   - "open-source-communities"
   - "united-states"
-coverImage: "iran.jpg"
+images: ["/blog/2021/10/iran.jpg"]
 ---
 
 I was visiting the Fedora Council ticket tracker when I noticed [this ticket](https://pagure.io/Fedora-Council/tickets/issue/377) up for discussion. The ticket's purpose is minor and appears inconsequential. It involves adding some legal text to the Fedora Accounts system. The change is related to [Export Administration Regulations](https://docs.microsoft.com/en-us/compliance/regulatory/offering-ear) (the "EAR") as maintained by the United States Department of Commerce. And the change is not actually a change, but a clarification of a policy that has always been in effect.

--- a/content/blog/2021/12/4-metrics-open-source-investments.md
+++ b/content/blog/2021/12/4-metrics-open-source-investments.md
@@ -18,7 +18,7 @@ tags:
   - "reflections"
   - "sustainability"
   - "working-together"
-coverImage: "sustainable-investments.jpg"
+images: ["/blog/2021/12/sustainable-investments.jpg"]
 ---
 
 How do we understand value when we talk about sustainability? What does investing in open source mean? The meaning is different for many people because of an implicit understanding of what open source means.

--- a/content/blog/2022/02/crystalcraftmc-forums-sunset.md
+++ b/content/blog/2022/02/crystalcraftmc-forums-sunset.md
@@ -9,7 +9,7 @@ tags:
   - "gaming"
   - "infrastructure"
   - "minecraft"
-coverImage: "crystalcraftmc-forums-sunset.jpg"
+images: ["/blog/2022/02/crystalcraftmc-forums-sunset.jpg"]
 ---
 
 It is with a sad heart that I share that the `crystalcraftmc.com` forums are permanently retired as of 6 February 2022. Nearly ten years ago, in August 2012, I founded a Minecraft multiplayer game server. It would eventually become known as CrystalCraftMC. I [passed the torch](https://web.archive.org/web/20210103155344/https://crystalcraftmc.com/?page=2) for the game server in April 2018. CrystalCraftMC got a second life from the dedicated player community until December 2018 when it was [shuttered for good](https://web.archive.org/web/20210614054749/https://crystalcraftmc.com/threads/survival-and-creative-world-downloads-now-available.2708/). Today's news is sad to me as it marks the official end of the online presence of CrystalCraftMC after nearly a decade.

--- a/content/blog/2022/08/synchronized.md
+++ b/content/blog/2022/08/synchronized.md
@@ -7,7 +7,7 @@ tags:
   - "life-lessons"
   - "spirituality"
   - "what-its-all-about"
-coverImage: "synchronized.jpg"
+images: ["/blog/2022/08/synchronized.jpg"]
 ---
 
 _Read more of [my poetry](https://jwfblog.wpenginepowered.com/category/poems/) on my blog._

--- a/content/blog/2022/10/chaoss-dei-review-reflection.md
+++ b/content/blog/2022/10/chaoss-dei-review-reflection.md
@@ -16,7 +16,7 @@ tags:
   - "reflections"
   - "research-and-learning"
   - "sustainability"
-coverImage: "chaoss-dei-reflection.png"
+images: ["/blog/2022/10/chaoss-dei-reflection.png"]
 ---
 
 Since February 2021, the CHAOSS Project is conducting a funded, long-term review of its governance, practices, and processes in a diversity, equity, and inclusion (D.E.I.) "audit." I originally joined as an internal community liaison and initially helped to identify a team of D.E.I. practitioners external to the CHAOSS Project to support this work. Thanks to the support of the Ford Foundation, we are slowly approaching the two-year anniversary of when this work began.

--- a/content/blog/2022/10/new-digital-public-goods.md
+++ b/content/blog/2022/10/new-digital-public-goods.md
@@ -21,7 +21,7 @@ tags:
   - "teaching-open-source"
   - "unicef"
   - "working-together"
-coverImage: "UN0441160_0.jpeg"
+images: ["/blog/2022/10/UN0441160_0.jpeg"]
 ---
 
 [_Originally published on 27 September 2022 via unicef.org_.](https://www.unicef.org/innovation/stories/spurring-new-digital-public-goods)

--- a/content/blog/2022/11/scrub-gently-community-survey.md
+++ b/content/blog/2022/11/scrub-gently-community-survey.md
@@ -11,7 +11,7 @@ tags:
   - "data-analysis"
   - "fedora-planet"
   - "open-source-communities"
-coverImage: "scrub-gently-community-survey.jpg"
+images: ["/blog/2022/11/scrub-gently-community-survey.jpg"]
 ---
 
 Recently, my team with the [CHAOSS Project](https://chaoss.community/) had a data concern emerge when I was working on a project to run a community survey. This community had never run a survey before, and it was the first notable event where the project made an explicit, structured ask for feedback from the community. As a result, this first experience was also a calibration event, so we could guide this kind of work in future years.

--- a/content/blog/2022/11/write-obsolescence.md
+++ b/content/blog/2022/11/write-obsolescence.md
@@ -13,7 +13,7 @@ tags:
   - "reflections"
   - "unicef"
   - "writing"
-coverImage: "write-obsolescence.jpg"
+images: ["/blog/2022/11/write-obsolescence.jpg"]
 ---
 
 This thought was pressed into my mind as I looked over all that I had created. Facing the inevitable end of one life chapter as it transitions into a new one, I recognized one possible way to improve our individual impact through documentation. Software and product documentation are classified as technical writing. While they differ in scope, they share a connection to other forms of written works like novels and newspapers; they are collections of a commonly understood, codified language meant to convey a meaning to other humans. The goal of writing yourself into obsolescence is not to create content for content's sake. The goal is to create information pathways that leave behind a guiding light for those who come after us. The goal is to create some form of media or content that communicates information of value to someone else (even including your future self).

--- a/content/blog/2022/12/middle-path.md
+++ b/content/blog/2022/12/middle-path.md
@@ -8,7 +8,7 @@ tags:
   - "reflections"
   - "spirituality"
   - "what-its-all-about"
-coverImage: "middle-path.jpg"
+images: ["/blog/2022/12/middle-path.jpg"]
 ---
 
 The answer suddenly appeared that the only way to solve my dilemma of two split worlds was to find the middle path.

--- a/content/blog/2022/12/open-source-product-roadmaps.md
+++ b/content/blog/2022/12/open-source-product-roadmaps.md
@@ -9,7 +9,7 @@ tags:
   - "fedora-planet"
   - "open-source"
   - "open-source-communities"
-coverImage: "three-product-roadmaps.jpg"
+images: ["/blog/2022/12/three-product-roadmaps.jpg"]
 ---
 
 In my daily reading, I came across three product roadmaps from [Proton](https://proton.me/about), developers of several open source, privacy-centered products. These include products like Proton Mail, Proton VPN, and Proton Drive. The product roadmaps shared by Proton play a tactical role. They inform consumers and engaged customers about exciting changes yet to come. It gets people excited about the product's future. Additionally, it builds an engaged user base that is more willing to experiment and try new features.

--- a/content/blog/2023/05/digitalism.md
+++ b/content/blog/2023/05/digitalism.md
@@ -7,7 +7,7 @@ tags:
   - "digital-era"
   - "fedora-planet"
   - "mental-health"
-coverImage: "digitalism.jpg"
+images: ["/blog/2023/05/digitalism.jpg"]
 ---
 
 _Read more of [my poetry](https://jwfblog.wpenginepowered.com/category/poems/) on my blog._

--- a/content/blog/2023/05/trust-and-community.md
+++ b/content/blog/2023/05/trust-and-community.md
@@ -14,7 +14,7 @@ tags:
   - "reflections"
   - "things-you-should-know-understand"
   - "what-its-all-about"
-coverImage: "i-am-wilderness.jpg"
+images: ["/blog/2023/05/i-am-wilderness.jpg"]
 ---
 
 Trust is a word and a concept that is on my mind lately. Trust is an idea that permeates all levels of our waking consciousness, and impacts how we build connections and relationships with other human beings. It is something impossible to ignore, yet it is ironically hard to define and pin down. Beyond what is written in a dictionary, what _is_ trust? What does trust look like? What does trust feel like? Anyone who works in "community work" knows that trust is often the fundamental tie between [community leadership](https://jwfblog.wpenginepowered.com/tag/community-management/) and community members. A leader wants to be trusted by the people whom they represent, and a person wants to trust their leaders to represent them fairly and accurately.

--- a/content/blog/2023/06/be-what-you-see.md
+++ b/content/blog/2023/06/be-what-you-see.md
@@ -12,7 +12,7 @@ tags:
   - "opinion"
   - "privilege"
   - "reflections"
-coverImage: "cannot-be-what-cannot-see.jpg"
+images: ["/blog/2023/06/cannot-be-what-cannot-see.jpg"]
 ---
 
 My musing this time is an underdeveloped thought about diversity, equity, & inclusion; allyship; and being a white person. Last year in October 2022, I attended the excellent [Inclusion & Diversity in Open Source summit](https://2022.allthingsopen.org/events/inclusion-diversity-in-open-source/) at [All Things Open 2022](https://2022.allthingsopen.org/). There were several speakers who shared experiences and perspectives about diversity, equity, inclusion, and belonging. I appreciated the elevation of diverse voices and people whose experiences are historically relegated to the periphery of Western society. For myself and also our world, it is important that more light is shone on these stories. The event also caused me to reflect on my own identity as a white American male. I began to interrogate what "whiteness" and being white meant.

--- a/content/blog/2023/12/2023-quiet-2024-theme-storytelling.md
+++ b/content/blog/2023/12/2023-quiet-2024-theme-storytelling.md
@@ -10,7 +10,7 @@ tags:
   - "fedora-planet"
   - "reflections"
   - "writing"
-coverImage: "2024-storytelling-theme.jpg"
+images: ["/blog/2023/12/2024-storytelling-theme.jpg"]
 ---
 
 2023 is almost over. It was a busy year. When I was a student, I used to write about what I was learning. But after finishing my studies, I stopped writing regularly. Now I want to focus on the future and adopt a storytelling theme for 2024. This post summarizes my intentions of committing to storytelling.

--- a/content/blog/2024/02/eventually-eternity.md
+++ b/content/blog/2024/02/eventually-eternity.md
@@ -7,7 +7,7 @@ tags:
   - "2020s"
   - "reflections"
   - "travel"
-coverImage: "eventually-for-eternity.jpg"
+images: ["/blog/2024/02/eventually-for-eternity.jpg"]
 ---
 
 _A poem to describe love from a constantly suspended state of waiting and wonder. Read more of [my poetry](https://jwfblog.wpenginepowered.com/category/poems/) on my blog._

--- a/content/blog/2024/03/this-moment.md
+++ b/content/blog/2024/03/this-moment.md
@@ -6,7 +6,7 @@ categories:
 tags: 
   - "reflections"
   - "what-its-all-about"
-coverImage: "this-moment.jpg"
+images: ["/blog/2024/03/this-moment.jpg"]
 ---
 
 _A short poem that I was inspired to write after a short drive running errands, and I was absorbed momentarily into the beauty of the natural world around me. Read more of [my poetry](https://jwfblog.wpenginepowered.com/category/poems/) on my blog._

--- a/content/blog/2024/03/win-win-for-all-outreachy.md
+++ b/content/blog/2024/03/win-win-for-all-outreachy.md
@@ -13,7 +13,7 @@ tags:
   - "internship"
   - "open-source"
   - "open-source-communities"
-coverImage: "win-win-for-all-outreachy.png"
+images: ["/blog/2024/03/win-win-for-all-outreachy.png"]
 ---
 
 This year, I am mentoring again with the [Outreachy internship program](https://www.outreachy.org/). It is my third time mentoring for Outreachy and my second time with the [Fedora Project](https://jwfblog.wpenginepowered.com/category/fedora/). However, it is my first time mentoring as a [Red Hat](https://jwfblog.wpenginepowered.com/category/red-hat/) associate. What also makes this time different from before is that I am mentoring a non-engineering project with Outreachy. Or in other words, my project does not _require_ an applicant to write any code. Evidently, the internship description was a hook. We received an extremely large wave of applicants literally overnight. Between 40-50 new contributors arrived to the Fedora Marketing Team in the first week. Planning tasks and contributions for beginners already took effort. Scaling that planning work overnight for up to 50 people simultaneously is extraordinarily difficult.

--- a/content/blog/2024/08/infra-amp-releng-hackfest-fedora-flock-2024.md
+++ b/content/blog/2024/08/infra-amp-releng-hackfest-fedora-flock-2024.md
@@ -15,7 +15,7 @@ tags:
   - "fedora-planet"
   - "flock"
   - "open-source-communities"
-coverImage: "community-operations-initiative.jpg"
+images: ["/blog/2024/08/community-operations-initiative.jpg"]
 ---
 
 This blog post summarizes the discussions and action items from the Infrastructure and Release Engineering workshop held at Flock 2024 in Rochester, New York, USA.

--- a/content/blog/2026/04/one-day.md
+++ b/content/blog/2026/04/one-day.md
@@ -11,7 +11,7 @@ tags:
   - reflections
   - things-you-should-know-understand
   - what-its-all-about
-coverImage: "one-day.png"
+images: ["/blog/2026/04/one-day.png"]
 ---
 
 It has been a minute.


### PR DESCRIPTION
Rename the `coverImage` frontmatter field to Hugo's standard `images` convention across all 108 blog posts that have a cover image, and update the Toph theme submodule to read from `.Params.images` instead of `.Params.coverImage`.

This enables Hugo's built-in OpenGraph and Twitter Card templates to automatically use the cover image for social sharing previews, instead of always falling back to the site logo. No custom OpenGraph template code was needed — conforming to Hugo's standard field name lets the existing built-in templates do the work.

All image paths are converted to absolute (e.g., "photo.jpg" → "/blog/2023/12/photo.jpg") so Hugo's internal templates resolve them correctly. The YAML format uses the single-line flow sequence (`images: ["/path/to/image.jpg"]`) for conciseness.