### PR TITLE
♻ ci: Split `build` and `deploy` jobs into separate workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,7 @@
 ---
-# Workflow for building and deploying a Hugo site to GitHub Pages
-name: Deploy Hugo site to GitHub Pages
+# Build the Hugo site on all pushes and pull requests.
+# Deployment is handled by the separate deploy.yaml workflow.
+name: Build Hugo site
 
 on:
   # Runs on pushes and pull requests to all branches
@@ -15,23 +16,18 @@ on:
   schedule:
     - cron: '15 8,20 * * *'
 
-# Opt into Node.js 24 for all actions to avoid deprecation warnings.
-# See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment.
+# Allow only one concurrent site build.
 # Skips runs queued between the run in-progress and latest queued.
 # Do NOT cancel in-progress runs to allow production deployments to complete.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: "pages-build-${{ github.ref }}"
+  cancel-in-progress: true
 
 # Default to bash
 defaults:
@@ -39,7 +35,6 @@ defaults:
     shell: bash
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
     env:
@@ -122,16 +117,3 @@ jobs:
         uses: actions/upload-pages-artifact@v5
         with:
           path: ./public
-
-  # Deployment job (only on pushes to main)
-  deploy:
-    if: github.ref == 'refs/heads/main'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,34 @@
+---
+# Deploy the Hugo site to GitHub Pages after a successful build on main.
+# Triggered by the build.yaml workflow completing on the main branch.
+name: Deploy to GitHub Pages
+
+on:
+  workflow_run:
+    workflows: ["Build Hugo site"]
+    types: [completed]
+    branches: [main]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment.
+# Skips runs queued between the run in-progress and latest queued.
+# Do NOT cancel in-progress runs to allow production deployments to complete.
+concurrency:
+  group: "pages-deploy"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    if: github.event.workflow_run.conclusion == 'success'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
The combined workflow caused the deploy job to appear as "skipped" on pull requests and non-main branches, which was distracting in the GitHub Actions UI. The `if`-guard on the deploy job was functionally correct, but the skipped status cluttered the PR checks view.

Split into two workflow files: `build.yaml` runs on all pushes, PRs, scheduled builds, and manual dispatch. `deploy.yaml` triggers via `workflow_run` only after a successful build on `main`. The deploy workflow never appears in the PR checks UI because it is not triggered by PR events at all.

The `deploy` workflow checks `workflow_run.conclusion == 'success'` to avoid deploying from a failed build. Concurrency groups are separated so build runs on feature branches do not block or cancel production deployments.